### PR TITLE
fix: Refine HeroSection video load event for smoother transition

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -37,7 +37,7 @@ const VimeoPlayer = dynamic(() => Promise.resolve(() => {
           const iframe = document.querySelector('iframe');
           if (iframe) {
             const player = new Player(iframe);
-            player.on('loaded', () => { // Changed 'play' to 'loaded'
+            player.on('loadeddata', () => { // Changed 'loaded' to 'loadeddata'
               document.dispatchEvent(new Event('vimeoLoaded')); // Écoute l'événement 'ready'
             });
           } else {


### PR DESCRIPTION
I changed the Vimeo player event in `HeroSection.tsx` from `loaded` to `loadeddata`.

The previous `loaded` event was firing too early, before video frames were available for rendering, leading to a white screen after the loading indicator disappeared.

The `loadeddata` event ensures that data for the current playback position (i.e., the first frame) is loaded, meaning the video can actually be displayed when the loading screen is hidden. This should prevent the white screen issue and provide a smoother visual transition for the background video.