### PR TITLE
fix: Address GIF loading and HeroSection mobile video event

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -37,7 +37,7 @@ const VimeoPlayer = dynamic(() => Promise.resolve(() => {
           const iframe = document.querySelector('iframe');
           if (iframe) {
             const player = new Player(iframe);
-            player.on('loadeddata', () => { // Changed 'loaded' to 'loadeddata'
+            player.on('canplay', () => { // Changed 'loadeddata' to 'canplay'
               document.dispatchEvent(new Event('vimeoLoaded')); // Écoute l'événement 'ready'
             });
           } else {

--- a/src/components/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail.tsx
@@ -28,6 +28,10 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ videoId, title, gif, pr
     };
   }, []);
 
+  if (!gif) {
+    console.error(`VideoThumbnail: GIF path is missing for videoId: ${videoId}, title: ${title}`);
+  }
+
   const handleInfoClick = (e: React.MouseEvent) => {
     if (preventClick) {
       e.preventDefault();
@@ -49,7 +53,7 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ videoId, title, gif, pr
           >
             <div className="relative w-[400px] h-[263px] overflow-hidden rounded-xl">
               {/* GIF uniquement sur les écrans non mobiles */}
-              {!isMobile && (
+              {!isMobile && gif && ( // Added '&& gif' here
                 <div className={`absolute inset-0 transition-opacity duration-500 ${isHovered ? 'opacity-100' : 'opacity-0'
                   }`}>
                   <Image


### PR DESCRIPTION
This commit includes two main changes based on your feedback:

1.  Portfolio GIF Loading (`VideoThumbnail.tsx`):
    - Added a console error log if the `gif` prop is missing when rendering a VideoThumbnail. This will help diagnose if GIF paths are not being correctly passed.
    - Conditionally render the GIF `next/image` component only if the `gif` prop is truthy. This prevents attempts to load an image with an invalid source. This is primarily a diagnostic and robustness improvement, as the root cause for reported GIF loading issues after initial optimizations is still under investigation.

2.  HeroSection Video Loading (`HeroSection.tsx`):
    - Changed the Vimeo player event listener from `loadeddata` to `canplay`. The `loadeddata` event was causing prolonged white screens on mobile devices. The `canplay` event is generally more reliable across devices, especially mobile, for indicating that the video has buffered enough to start playback without undue delay. This aims to provide a smoother loading experience for the background video on both desktop and mobile.