### PR TITLE
feat: Add preconnect links for Vimeo assets

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,8 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Lexend:wght@100;200;300;400;500;600;700&display=swap"
           rel="stylesheet"
         />
+        <link rel="preconnect" href="https://player.vimeo.com" />
+        <link rel="preconnect" href="https://i.vimeocdn.com" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -37,7 +37,12 @@ const VimeoPlayer = dynamic(() => Promise.resolve(() => {
           const iframe = document.querySelector('iframe');
           if (iframe) {
             const player = new Player(iframe);
-            player.on('canplay', () => { // Changed 'loadeddata' to 'canplay'
+            // Using 'play' event: Other events like 'loaded', 'loadeddata', or 'canplay'
+            // were found to hide the loading screen prematurely on initial page loads,
+            // leading to a white screen before the video was visible. 'play' ensures
+            // the video has actually started playback. If loading still feels long,
+            // it's likely due to video size/delivery or player init time.
+            player.on('play', () => { // Changed 'canplay' back to 'play'
               document.dispatchEvent(new Event('vimeoLoaded')); // Écoute l'événement 'ready'
             });
           } else {


### PR DESCRIPTION
Added `<link rel="preconnect">` hints for `https://player.vimeo.com` and `https://i.vimeocdn.com` to the `<head>` in `src/app/layout.tsx`.

This allows the browser to establish early connections to these domains, reducing latency for DNS lookup, TCP handshake, and TLS negotiation when the Vimeo player and video assets are requested.

This optimization aims to speed up the initial phase of video loading, potentially improving the perceived performance of the background video in the HeroSection.