### PR TITLE
feat: Add preconnect links for Vimeo assets

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,8 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Lexend:wght@100;200;300;400;500;600;700&display=swap"
           rel="stylesheet"
         />
+        <link rel="preconnect" href="https://player.vimeo.com" />
+        <link rel="preconnect" href="https://i.vimeocdn.com" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}


### PR DESCRIPTION
Added `<link rel="preconnect">` hints for `https://player.vimeo.com` and `https://i.vimeocdn.com` to the `<head>` in `src/app/layout.tsx`.

This allows the browser to establish early connections to these domains, reducing latency for DNS lookup, TCP handshake, and TLS negotiation when the Vimeo player and video assets are requested.

This optimization aims to speed up the initial phase of video loading, potentially improving the perceived performance of the background video in the HeroSection.